### PR TITLE
APIS-4691 - Added validateFieldDefinitions endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ npm-debug.log
 yarn-debug.log
 yarn-error.log
 
+.bloop
+.metals
+project/metals.sbt
     

--- a/app/uk/gov/hmrc/apipublisher/services/PublisherService.scala
+++ b/app/uk/gov/hmrc/apipublisher/services/PublisherService.scala
@@ -77,13 +77,20 @@ class PublisherService @Inject()(definitionService: DefinitionService,
         for {
           scopeErrors <- apiScopeConnector.validateScopes(apiAndScopes.scopes)
           apiErrors <- apiDefinitionConnector.validateAPIDefinition(apiAndScopes.apiWithoutFieldDefinitions)
+          fieldDefnErrors <- apiSubscriptionFieldsConnector.validateFieldDefinitions(apiAndScopes.fieldDefinitions.flatMap(_.fieldDefinitions))
         } yield {
-          if (scopeErrors.isEmpty && apiErrors.isEmpty) {
+          
+          if (scopeErrors.isEmpty && apiErrors.isEmpty && fieldDefnErrors.isEmpty) {
             None
           } else {
-            Some(JsObject(Seq.empty[(String, JsValue)] ++
-              scopeErrors.map("scopeErrors" -> _) ++
-              apiErrors.map("apiDefinitionErrors" -> _)))
+            Some(
+              JsObject(
+                Seq.empty[(String, JsValue)] ++
+                  scopeErrors.map("scopeErrors" -> _) ++
+                  apiErrors.map("apiDefinitionErrors" -> _) ++
+                  fieldDefnErrors.map("fieldDefinitionErrors" -> _)
+              )
+            )
           }
         }
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val compile = Seq(
   "com.damnhandy" % "handy-uri-templates" % "2.1.6",
   "org.julienrf" %% "play-json-derived-codecs" % "6.0.0",
   "com.typesafe.play" %% "play-json" % "2.7.1",
-  "org.typelevel" %% "cats-core" % "2.0.0"
+  "org.typelevel" %% "cats-core" % "2.1.0"
 )
 
 lazy val scope: String = "test,it"

--- a/test/uk/gov/hmrc/apipublisher/services/PublisherServiceSpec.scala
+++ b/test/uk/gov/hmrc/apipublisher/services/PublisherServiceSpec.scala
@@ -174,11 +174,31 @@ class PublisherServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures 
 
       given(mockApiDefinitionConnector.validateAPIDefinition(any[JsObject])(any[HeaderCarrier])).willReturn(successful(None))
       given(mockApiScopeConnector.validateScopes(any[JsValue])(any[HeaderCarrier])).willReturn(successful(None))
+      given(mockApiSubscriptionFieldsConnector.validateFieldDefinitions(any())(any[HeaderCarrier])).willReturn(successful(None))
 
-      val future = await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
+      await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
 
       verify(mockApiDefinitionConnector).validateAPIDefinition(any[JsObject])(any[HeaderCarrier])
       verify(mockApiScopeConnector).validateScopes(any[JsValue])(any[HeaderCarrier])
+      verify(mockApiSubscriptionFieldsConnector).validateFieldDefinitions(any())(any[HeaderCarrier])
+
+    }
+
+    "Fail when Field Definition is invalid" in new Setup {
+      
+      val errorString = """{"error":"blah"}"""
+      given(mockApiDefinitionConnector.validateAPIDefinition(any[JsObject])(any[HeaderCarrier])).willReturn(successful(None))
+      given(mockApiScopeConnector.validateScopes(any[JsValue])(any[HeaderCarrier])).willReturn(successful(None))
+      given(mockApiSubscriptionFieldsConnector.validateFieldDefinitions(any())(any[HeaderCarrier])).willReturn(successful(Some(Json.parse(errorString))))
+
+      val result = await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
+
+      verify(mockApiDefinitionConnector).validateAPIDefinition(any[JsObject])(any[HeaderCarrier])
+      verify(mockApiScopeConnector).validateScopes(any[JsValue])(any[HeaderCarrier])
+      verify(mockApiSubscriptionFieldsConnector).validateFieldDefinitions(any())(any[HeaderCarrier])
+      
+      result.isDefined shouldBe true
+      Json.stringify(result.get) shouldBe s"""{"fieldDefinitionErrors":$errorString}""" 
 
     }
 
@@ -187,11 +207,15 @@ class PublisherServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures 
       val errorString = """{"error":"blah"}"""
       given(mockApiDefinitionConnector.validateAPIDefinition(any[JsObject])(any[HeaderCarrier])).willReturn(successful(None))
       given(mockApiScopeConnector.validateScopes(any[JsValue])(any[HeaderCarrier])).willReturn(successful(Some(Json.parse(errorString))))
+      given(mockApiSubscriptionFieldsConnector.validateFieldDefinitions(any())(any[HeaderCarrier])).willReturn(successful(None))
+
 
       val result = await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
 
       verify(mockApiDefinitionConnector).validateAPIDefinition(any[JsObject])(any[HeaderCarrier])
       verify(mockApiScopeConnector).validateScopes(any[JsValue])(any[HeaderCarrier])
+      verify(mockApiSubscriptionFieldsConnector).validateFieldDefinitions(any())(any[HeaderCarrier])
+
 
       result.isDefined shouldBe true
       Json.stringify(result.get) shouldBe s"""{"scopeErrors":$errorString}"""
@@ -203,11 +227,13 @@ class PublisherServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures 
       given(mockApiDefinitionConnector.validateAPIDefinition(any[JsObject])(any[HeaderCarrier]))
         .willReturn(successful(Some(Json.parse( """{"error":"blah"}"""))))
       given(mockApiScopeConnector.validateScopes(any[JsValue])(any[HeaderCarrier])).willReturn(successful(None))
+      given(mockApiSubscriptionFieldsConnector.validateFieldDefinitions(any())(any[HeaderCarrier])).willReturn(successful(None))
 
       val result = await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
 
       verify(mockApiDefinitionConnector).validateAPIDefinition(any[JsObject])(any[HeaderCarrier])
       verify(mockApiScopeConnector).validateScopes(any[JsValue])(any[HeaderCarrier])
+      verify(mockApiSubscriptionFieldsConnector).validateFieldDefinitions(any())(any[HeaderCarrier])
 
       result.isDefined shouldBe true
       Json.stringify(result.get) shouldBe s"""{"apiDefinitionErrors":$errorString}"""
@@ -220,11 +246,13 @@ class PublisherServiceSpec extends UnitSpec with MockitoSugar with ScalaFutures 
       given(mockApiDefinitionConnector.validateAPIDefinition(any[JsObject])(any[HeaderCarrier]))
         .willReturn(successful(Some(Json.parse(apiDefinitionErrorString))))
       given(mockApiScopeConnector.validateScopes(any[JsValue])(any[HeaderCarrier])).willReturn(successful(Some(Json.parse(scopeErrorString))))
+      given(mockApiSubscriptionFieldsConnector.validateFieldDefinitions(any())(any[HeaderCarrier])).willReturn(successful(None))
 
       val result = await(publisherService.validateAPIDefinitionAndScopes(apiAndScopes))
 
       verify(mockApiDefinitionConnector).validateAPIDefinition(any[JsObject])(any[HeaderCarrier])
       verify(mockApiScopeConnector).validateScopes(any[JsValue])(any[HeaderCarrier])
+      verify(mockApiSubscriptionFieldsConnector).validateFieldDefinitions(any())(any[HeaderCarrier])
 
       result.isDefined shouldBe true
       Json.stringify(result.get) shouldBe s"""{"scopeErrors":$scopeErrorString,"apiDefinitionErrors":$apiDefinitionErrorString}"""


### PR DESCRIPTION
This is to validate regex's in the Field Definition.